### PR TITLE
Fix ARM32/ARM64 patterns

### DIFF
--- a/vcxproj2cmake/Config.cs
+++ b/vcxproj2cmake/Config.cs
@@ -13,8 +13,8 @@ record Config(Regex MSBuildProjectConfigPattern, string CMakeExpression)
         new Config(new(@"^Release\|"), "$<$<CONFIG:Release>:{0}>"),
         new Config(new(@"\|(Win32|x86)$"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,x86>:{0}>"),
         new Config(new(@"\|x64$"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,x64>:{0}>"),
-        new Config(new(@"\|ARM32"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,ARM32>:{0}>"),
-        new Config(new(@"\|ARM64"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,ARM64>:{0}>")
+        new Config(new(@"\|ARM32$"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,ARM32>:{0}>"),
+        new Config(new(@"\|ARM64$"), "$<$<STREQUAL:$<TARGET_PROPERTY:ARCHITECTURE_ID>,ARM64>:{0}>")
     ];
 
     public static bool IsMSBuildProjectConfigNameSupported(string projectConfig)


### PR DESCRIPTION
## Summary
- tighten regex patterns for ARM32/ARM64 platforms

## Testing
- `dotnet build --configuration Release vcxproj2cmake/vcxproj2cmake.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_683f54e75528832fb3539a20ebd186b0