### PR TITLE
Support header-only libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 * Accepts either a list of `.vcxproj` project files or a `.sln` solution file as input.
 * Supports console, Win32, Dynamic-Link Library (DLL), and Static Library project types.
+  Includes detection of header-only libraries.
 * Leverages CMake generator expressions for property values that are specific to certain build configurations (Debug, Release, Win32, x64).
 * The following MSBuild project properties are converted/taken into account:
 

--- a/vcxproj2cmake/Program.cs
+++ b/vcxproj2cmake/Program.cs
@@ -212,6 +212,7 @@ static class Program
                 ProjectReferences = projectInfo.ProjectReferences,
                 LinkerSubsystem = projectInfo.LinkerSubsystem,
                 LinkLibraryDependenciesEnabled = projectInfo.LinkLibraryDependenciesEnabled,
+                IsHeaderOnlyLibrary = projectInfo.IsHeaderOnlyLibrary,
                 UsesOpenMP = projectInfo.UsesOpenMP,
                 QtVersion = projectInfo.QtVersion,
                 RequiresQtMoc = projectInfo.RequiresQtMoc,

--- a/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
+++ b/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
@@ -24,7 +24,9 @@ find_package(Qt{{ qt_version }} REQUIRED COMPONENTS {{ qt_modules | array.map "c
 find_package({{ package.cmake_config_name }} REQUIRED CONFIG)
 {{~ end ~}}
 
-{{~ if configuration_type == "Application" ~}}
+{{~ if is_header_only_library ~}}
+add_library({{ project_name }} INTERFACE)
+{{~ else if configuration_type == "Application" ~}}
 add_executable({{ project_name }}{{ if linker_subsystem == "Windows" }} WIN32{{ end }}
 {{~ else if configuration_type == "StaticLibrary" ~}}
 add_library({{ project_name }} STATIC
@@ -33,10 +35,12 @@ add_library({{ project_name }} SHARED
 {{~ else ~}}
 {{ fail $"Unsupported configuration type: {configuration_type}" }}
 {{~ end ~}}
+{{~ if !is_header_only_library ~}}
     {{~ for file in source_files | array.sort ~}}
     {{ file | translate_msbuild_macros | normalize_path }}
     {{~ end ~}}
 )
+{{~ end ~}}
 
 {{~ if requires_qt_moc || requires_qt_uic || requires_qt_rcc ~}}
 set_target_properties({{ project_name }} PROPERTIES
@@ -54,7 +58,7 @@ set_target_properties({{ project_name }} PROPERTIES
 {{~ end -}}
 
 {{~ if cpp_language_standard != null || (clanguage_standard != null && clanguage_standard != "Default") ~}}
-target_compile_features({{ project_name }} PUBLIC
+target_compile_features({{ project_name }} {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
     {{- if cpp_language_standard -}}
         {{- case cpp_language_standard -}}
         {{- when "stdcpplatest" }} cxx_std_23
@@ -91,7 +95,7 @@ target_include_directories({{ project_name }}
         {{~ end ~}}  
 {{~ end ~}}
 {{~ if !include_paths.is_empty ~}}
-    PUBLIC
+    {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
         {{~ for kvp in include_paths.values ~}}
         {{~ for path in kvp.value ~}}
         {{ string.replace kvp.key.cmake_expression "{0}" (path | translate_msbuild_macros | normalize_path | prepend_relative_paths_with_cmake_current_source_dir) }}
@@ -104,7 +108,7 @@ target_include_directories({{ project_name }}
 
 {{~ if !defines.is_empty ~}}
 target_compile_definitions({{ project_name }}
-    PUBLIC
+    {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
         {{~ for kvp in defines.values ~}}
         {{~ for define in kvp.value ~}}
         {{ string.replace kvp.key.cmake_expression "{0}" define }}
@@ -116,7 +120,7 @@ target_compile_definitions({{ project_name }}
 
 {{~ if !linker_paths.is_empty ~}}
 target_link_directories({{ project_name }}
-    PUBLIC
+    {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
         {{~ for kvp in linker_paths.values ~}}
         {{~ for path in kvp.value ~}}
         {{ string.replace kvp.key.cmake_expression "{0}" (path | translate_msbuild_macros | normalize_path) }}
@@ -138,7 +142,7 @@ target_link_directories({{ project_name }}
 ~}}
 {{~ if !libraries.is_empty || link_library_dependencies_effective || qt_modules.size > 0 || conan_packages.size > 0 ~}}
 target_link_libraries({{ project_name }}
-    PUBLIC
+    {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
         {{~ for kvp in libraries.values ~}}
         {{~ for library in kvp.value ~}}
         {{ string.replace kvp.key.cmake_expression "{0}" (library | translate_msbuild_macros | normalize_path) }}
@@ -163,7 +167,7 @@ target_link_libraries({{ project_name }}
 
 {{~ if !options.is_empty ~}}
 target_compile_options({{ project_name }}
-    PUBLIC
+    {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
         {{~ for kvp in options.values ~}}
         {{~ for option in kvp.value ~}}
         {{ string.replace kvp.key.cmake_expression "{0}" option }}


### PR DESCRIPTION
## Summary
- add `IsHeaderOnlyLibrary` flag to `ProjectInfo`
- compute header-only state in `ParseProjectFile`
- propagate the new flag when filtering libraries
- adjust Scriban template to emit `INTERFACE` targets for header-only libraries

## Testing
- `dotnet build vcxproj2cmake/vcxproj2cmake.csproj --nologo`

------
https://chatgpt.com/codex/tasks/task_e_6841fb6e7bac832f922488c55abb48ac