### PR TITLE
Support config-specific precompiled headers, revise how config-dependent settings are mapped

### DIFF
--- a/vcxproj2cmake/Config.cs
+++ b/vcxproj2cmake/Config.cs
@@ -17,6 +17,11 @@ record Config(Regex MSBuildProjectConfigPattern, string CMakeExpression)
         new Config(new(@"\|ARM64$"), "$<$<STREQUAL:$<CMAKE_CXX_COMPILER_ARCHITECTURE_ID>,ARM64>:{0}>")
     ];
 
+    public bool MatchesProjectConfigName(string projectConfig)
+    {
+        return MSBuildProjectConfigPattern.IsMatch(projectConfig);
+    }
+
     public static bool IsMSBuildProjectConfigNameSupported(string projectConfig)
     {
         return Regex.IsMatch(projectConfig, @"^(Debug|Release)\|(Win32|x86|x64|ARM32|ARM64)$");
@@ -27,10 +32,8 @@ record ConfigDependentSetting
 {
     public required OrderedDictionary<Config, string> Values { get; init; }
 
-    public static readonly ConfigDependentSetting Empty = new()
-    {
-        Values = []
-    };
+    public required string SettingName { get; init; }
+    public required string DefaultValue { get; init; }
 
     public static ConfigDependentSetting Parse(
         Dictionary<string, string>? settings,
@@ -40,7 +43,12 @@ record ConfigDependentSetting
         ILogger logger)
     {
         if (settings == null || settings.Count == 0)
-            return Empty;
+            return new ConfigDependentSetting
+            {
+                Values = [],
+                SettingName = settingName,
+                DefaultValue = defaultValue
+            };
 
         var effectiveSettings = new Dictionary<string, string>(settings);
         foreach (var config in projectConfigurations)
@@ -54,7 +62,7 @@ record ConfigDependentSetting
         string? FilterByConfig(Config config)
         {
             return allSettingValues
-                .Where(s => effectiveSettings.All(kvp => config.MSBuildProjectConfigPattern.IsMatch(kvp.Key) == (kvp.Value == s)))
+                .Where(s => effectiveSettings.All(kvp => config.MatchesProjectConfigName(kvp.Key) == (kvp.Value == s)))
                 .FirstOrDefault(s => s != commonSettingValue);
         }
 
@@ -70,7 +78,7 @@ record ConfigDependentSetting
                 values[config] = filteredValues;
         }
 
-        var result = new ConfigDependentSetting { Values = values };
+        var result = new ConfigDependentSetting { Values = values, SettingName = settingName, DefaultValue = defaultValue };
 
         var skippedSettings = settings.Values
             .Except(result.Values.Values)
@@ -81,36 +89,43 @@ record ConfigDependentSetting
         return result;
     }
 
+    public string? GetValue(string projectConfig)
+    {
+        var config = Config.Configs.SingleOrDefault(config => config.MatchesProjectConfigName(projectConfig) && Values.ContainsKey(config));
+        if (config != null)
+            return Values[config];        
+        return Values.GetValueOrDefault(Config.CommonConfig);
+    }
+
     public bool IsEmpty => Values.Count == 0;
 }
 
 record ConfigDependentMultiSetting
 {
     public required OrderedDictionary<Config, string[]> Values { get; init; }
-
-    public static readonly ConfigDependentMultiSetting Empty = new()
-    {
-        Values = []
-    };
+    public required string SettingName { get; init; }
+    public required string[] DefaultValue { get; init; }
 
     public static ConfigDependentMultiSetting Parse(
-        Dictionary<string, string>? settings,
+        Dictionary<string, string[]>? settings,
         string settingName,
-        Func<string, string[]> parser,
         string[] defaultValue,
         IEnumerable<string> projectConfigurations,
         ILogger logger)
     {
         if (settings == null || settings.Count == 0)
-            return Empty;
+            return new ConfigDependentMultiSetting
+            {
+                Values = [],
+                SettingName = settingName,
+                DefaultValue = defaultValue
+            };
 
-        var parsedSettings = settings.ToDictionary(kvp => kvp.Key, kvp => parser(kvp.Value));
-
-        var effectiveSettings = new Dictionary<string, string[]>(parsedSettings);
+        var effectiveSettings = new Dictionary<string, string[]>(settings);
         foreach (var config in projectConfigurations)
             if (!effectiveSettings.ContainsKey(config))
                 effectiveSettings[config] = defaultValue;
-        
+
         var allSettingValues = effectiveSettings.Values.SelectMany(s => s).Distinct().ToArray();
 
         var commonSettingValues = allSettingValues.Where(s => effectiveSettings.All(kvp => kvp.Value.Contains(s))).ToArray();
@@ -118,7 +133,7 @@ record ConfigDependentMultiSetting
         string[] FilterByConfig(Config config)
         {
             return allSettingValues
-                .Where(s => effectiveSettings.All(kvp => config.MSBuildProjectConfigPattern.IsMatch(kvp.Key) == kvp.Value.Contains(s)))
+                .Where(s => effectiveSettings.All(kvp => config.MatchesProjectConfigName(kvp.Key) == kvp.Value.Contains(s)))
                 .Except(commonSettingValues)
                 .ToArray();
         }
@@ -135,9 +150,9 @@ record ConfigDependentMultiSetting
                 values[config] = filteredValues;
         }
 
-        var result = new ConfigDependentMultiSetting { Values = values };
+        var result = new ConfigDependentMultiSetting { Values = values, SettingName = settingName, DefaultValue = defaultValue };
 
-        var skippedSettings = parsedSettings.Values
+        var skippedSettings = settings.Values
             .SelectMany(s => s)
             .Except(result.Values.Values.SelectMany(s => s))
             .ToArray();
@@ -145,6 +160,15 @@ record ConfigDependentMultiSetting
             logger.LogWarning($"The following values for setting {settingName} were ignored because they are specific to certain build configurations: {string.Join(", ", skippedSettings)}");
 
         return result;
+    }
+
+    public string[] GetValue(string projectConfig)
+    {
+        return new[] { Config.CommonConfig }
+            .Concat(Config.Configs)
+            .Where(config => config.MatchesProjectConfigName(projectConfig) && Values.ContainsKey(config))
+            .SelectMany(config => Values[config])
+            .ToArray();
     }
 
     public bool IsEmpty => Values.Count == 0;

--- a/vcxproj2cmake/Program.cs
+++ b/vcxproj2cmake/Program.cs
@@ -191,13 +191,14 @@ static class Program
                     logger!.LogInformation($"Removing explicit library dependency {dependencyTarget} from project {projectInfo.ProjectName} since LinkLibraryDependencies is enabled.");
                 }
 
-            var filteredLibraries = projectInfo.Libraries.Map(libraries => libraries.Except(dependencyTargets, StringComparer.OrdinalIgnoreCase).ToArray());
+            var filteredLibraries = projectInfo.Libraries.Map(libraries => libraries.Except(dependencyTargets, StringComparer.OrdinalIgnoreCase).ToArray(), projectInfo.ProjectConfigurations, logger!);
 
             return new ProjectInfo
             {
                 AbsoluteProjectPath = projectInfo.AbsoluteProjectPath,
                 ProjectName = projectInfo.ProjectName,
                 UniqueName = projectInfo.UniqueName,
+                ProjectConfigurations = projectInfo.ProjectConfigurations,
                 Languages = projectInfo.Languages,
                 ConfigurationType = projectInfo.ConfigurationType,
                 CppLanguageStandard = projectInfo.CppLanguageStandard,

--- a/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
+++ b/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
@@ -84,8 +84,15 @@ target_compile_features({{ project_name }} {{ if is_header_only_library }}INTERF
 
 {{~ end -}}
 
-{{~ if precompiled_header_file != null ~}}
-target_precompile_headers({{ project_name }} PRIVATE {{ precompiled_header_file | translate_msbuild_macros | normalize_path }})
+{{~ if !precompiled_header_file.is_empty ~}}
+target_precompile_headers({{ project_name }}
+    PRIVATE
+        {{~ for kvp in precompiled_header_file.values ~}}
+        {{~ if kvp.value != "" ~}}
+        {{ string.replace kvp.key.cmake_expression "{0}" (kvp.value | translate_msbuild_macros | normalize_path | prepend_relative_paths_with_cmake_current_source_dir) }}
+        {{~ end ~}}
+        {{~ end ~}}
+)
 
 {{~ end -}}
 


### PR DESCRIPTION
## Summary
- allow `PrecompiledHeader` setting to vary per configuration
- use config expressions to provide precompiled header path

## Testing
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684314164238832f9feccb3ced41a887