### PR TITLE
Add RuntimeLibrary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   `PrecompiledHeaderFile`
   `PreprocessorDefinitions`
   `PublicIncludeDirectories`
+  `RuntimeLibrary`
   `SubSystem`
   `TreatAngleIncludeAsExternal`
   `TreatSpecificWarningsAsErrors`

--- a/vcxproj2cmake/Program.cs
+++ b/vcxproj2cmake/Program.cs
@@ -242,6 +242,7 @@ static class Program
                 LinkLibraryDependenciesEnabled = projectInfo.LinkLibraryDependenciesEnabled,
                 IsHeaderOnlyLibrary = projectInfo.IsHeaderOnlyLibrary,
                 PrecompiledHeaderFile = projectInfo.PrecompiledHeaderFile,
+                RuntimeLibrary = projectInfo.RuntimeLibrary,
                 UsesOpenMP = projectInfo.UsesOpenMP,
                 QtVersion = projectInfo.QtVersion,
                 RequiresQtMoc = projectInfo.RequiresQtMoc,

--- a/vcxproj2cmake/ProjectInfo.cs
+++ b/vcxproj2cmake/ProjectInfo.cs
@@ -26,6 +26,7 @@ class ProjectInfo
     public required bool LinkLibraryDependenciesEnabled { get; init; }
     public required bool IsHeaderOnlyLibrary { get; init; }
     public required ConfigDependentSetting PrecompiledHeaderFile { get; init; }
+    public required ConfigDependentSetting RuntimeLibrary { get; init; }
     public required bool UsesOpenMP { get; init; }
     public required int? QtVersion { get; init; }
     public required bool RequiresQtMoc { get; init; }
@@ -257,6 +258,7 @@ class ProjectInfo
         var openMPSupport = ParseSetting("OpenMPSupport", compilerSettings, "false");
         var precompiledHeader = ParseSetting("PrecompiledHeader", compilerSettings, "NotUsing");
         var precompiledHeaderFile = ParseSetting("PrecompiledHeaderFile", compilerSettings, string.Empty);
+        var runtimeLibrary = ParseSetting("RuntimeLibrary", compilerSettings, string.Empty);
 
         var conanPackages =
             imports
@@ -302,6 +304,7 @@ class ProjectInfo
             LinkLibraryDependenciesEnabled = linkLibraryDependenciesEnabled,
             IsHeaderOnlyLibrary = isHeaderOnlyLibrary,
             PrecompiledHeaderFile = precompiledHeaderFile.Map((file, mode) => mode == "Use" ? file : null, precompiledHeader, projectConfigurations, logger),
+            RuntimeLibrary = runtimeLibrary,
             UsesOpenMP = openMPSupport.Values.Values.Contains("true", StringComparer.OrdinalIgnoreCase),
             QtVersion = qtVersion,
             RequiresQtMoc = requiresQtMoc,

--- a/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
+++ b/vcxproj2cmake/Resources/Templates/Project-CMakeLists.txt.scriban
@@ -57,6 +57,10 @@ set_target_properties({{ project_name }} PROPERTIES
 
 {{~ end -}}
 
+{{~ if !runtime_library.is_empty ~}}
+set_property(TARGET {{ project_name }} PROPERTY MSVC_RUNTIME_LIBRARY "{{~ for kvp in runtime_library.values ~}}{{ string.replace kvp.key.cmake_expression "{0}" kvp.value }}{{~ end ~}}")
+{{~ end -}}
+
 {{~ if cpp_language_standard != "Default" || clanguage_standard != "Default" ~}}
 target_compile_features({{ project_name }} {{ if is_header_only_library }}INTERFACE{{ else }}PUBLIC{{ end }}
     {{- if cpp_language_standard -}}


### PR DESCRIPTION
## Summary
- parse `RuntimeLibrary` from project files
- set `MSVC_RUNTIME_LIBRARY` in generated CMake
- copy property when filtering libraries
- document new property in README

## Testing
- `dotnet restore`
- `dotnet build --no-restore --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_6844a23cfd48832f815959fba8aa8490