### PR TITLE
Add tests for LinkLibraryDependencies handling

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -530,4 +530,121 @@ public class ConverterTests
                 """);
         }
     }
+
+    public class RemoveObsoleteLibrariesFromProjectReferencesTests
+    {
+        static string CreateAppProject(bool linkLibraryDependencies)
+        {
+            return $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                    <ItemGroup Label="ProjectConfigurations">
+                        <ProjectConfiguration Include="Debug|Win32">
+                            <Configuration>Debug</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                        <ProjectConfiguration Include="Release|Win32">
+                            <Configuration>Release</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                    </ItemGroup>
+                    <PropertyGroup>
+                        <ConfigurationType>Application</ConfigurationType>
+                    </PropertyGroup>
+                    <ItemGroup>
+                        <ProjectReference Include="..\\Lib\\Lib.vcxproj" />
+                    </ItemGroup>
+                    <ItemDefinitionGroup>
+                        <ProjectReference>
+                            <LinkLibraryDependencies>{(linkLibraryDependencies ? "true" : "false")}</LinkLibraryDependencies>
+                        </ProjectReference>
+                        <Link>
+                            <AdditionalDependencies>Lib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+                        </Link>
+                    </ItemDefinitionGroup>
+                </Project>
+                """;
+        }
+
+        [Fact]
+        public void Given_ProjectLinksLibraryExplicitlyAndLinkLibraryDependenciesDisabled_When_Converted_Then_LibraryIsPreserved()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Lib/Lib.vcxproj", new(TestData.CreateProject("Lib", "StaticLibrary")));
+            fileSystem.AddFile(@"App/App.vcxproj", new(CreateAppProject(false)));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            // Act
+            converter.Convert(
+                projectFiles: [new(@"App/App.vcxproj"), new(@"Lib/Lib.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            // Assert
+            AssertEx.FileHasContent(@"App/CMakeLists.txt", fileSystem, """
+                cmake_minimum_required(VERSION 3.13)
+                project(App)
+
+
+                add_executable(App
+                )
+
+                target_link_libraries(App
+                    PUBLIC
+                        Lib.lib
+                )
+                """);
+        }
+
+        [Fact]
+        public void Given_ProjectLinksLibraryExplicitlyAndLinkLibraryDependenciesEnabled_When_Converted_Then_LibraryIsRemovedAndLogged()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Lib/Lib.vcxproj", new(TestData.CreateProject("Lib", "StaticLibrary")));
+            fileSystem.AddFile(@"App/App.vcxproj", new(CreateAppProject(true)));
+
+            var logger = new InMemoryLogger();
+            var converter = new Converter(fileSystem, logger);
+
+            // Act
+            converter.Convert(
+                projectFiles: [new(@"App/App.vcxproj"), new(@"Lib/Lib.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            // Assert
+            AssertEx.FileHasContent(@"App/CMakeLists.txt", fileSystem, """
+                cmake_minimum_required(VERSION 3.13)
+                project(App)
+
+
+                add_executable(App
+                )
+
+                target_link_libraries(App
+                    PUBLIC
+                        Lib
+                )
+                """);
+
+            Assert.Contains(
+                "Removing explicit library dependency Lib.lib from project App since LinkLibraryDependencies is enabled.",
+                logger.AllMessageText);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- cover `RemoveObsoleteLibrariesFromProjectReferences` via `Converter.Convert`
- verify that explicit libs remain when `LinkLibraryDependencies` is disabled
- verify that explicit libs are removed and logged when enabled

## Testing
- `dotnet build --no-restore`
- `dotnet test vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj --no-build --verbosity minimal` *(fails: Directory contains two or more projects)*

------
https://chatgpt.com/codex/tasks/task_e_684f4ba837c0832fa16bac645b4aa75e