### PR TITLE
Add test for EnableStandaloneProjectBuilds

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -174,6 +174,51 @@ public class ConverterTests
         }
     }
 
+    public class EnableStandaloneProjectBuildsTests
+    {
+        [Fact]
+        public void Given_ProjectReferencesAnotherProject_When_ConvertedWithEnableStandaloneProjectBuilds_Then_ProjectFileContainsAddSubdirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Lib/Lib.vcxproj", new(TestData.CreateProject("Lib", "StaticLibrary")));
+            fileSystem.AddFile(@"App/App.vcxproj", new(TestData.CreateProject("App", "Application", "..\\Lib\\Lib.vcxproj")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            // Act
+            converter.Convert(
+                projectFiles: [new(@"App/App.vcxproj"), new(@"Lib/Lib.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: true,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            // Assert
+            AssertEx.FileHasContent(@"App/CMakeLists.txt", fileSystem, """
+                cmake_minimum_required(VERSION 3.13)
+                project(App)
+
+                if(NOT TARGET Lib)
+                    add_subdirectory(../Lib "${CMAKE_BINARY_DIR}/Lib")
+                endif()
+
+
+                add_executable(App
+                )
+
+                target_link_libraries(App
+                    PUBLIC
+                        Lib
+                )
+                """);
+        }
+    }
+
     public class IndentStyleAndIndentSizeTests
     {
 


### PR DESCRIPTION
## Summary
- add new `StandaloneProjectBuildsTests` verifying `add_subdirectory` is generated when enabling standalone project builds

## Testing
- `dotnet build vcxproj2cmake.sln --no-restore --verbosity minimal`
- `dotnet test vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj --no-build --settings runsettings.runsettings --verbosity minimal` *(fails: Could not find file '/workspace/vcxproj2cmake/vcxproj2cmake.Tests/bin/Debug/net9.0/..\Lib\Project.vcxproj')*

------
https://chatgpt.com/codex/tasks/task_e_68508d9b05c4832fbd93eaf03d503d88