### PR TITLE
Add language detection unit tests

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -514,6 +514,126 @@ public class ConverterTests
         }
     }
 
+    public class LanguageDetectionTests
+    {
+        static string CreateProject(params string[] sources)
+            => $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+            <ItemGroup Label="ProjectConfigurations">
+                <ProjectConfiguration Include="Debug|Win32">
+                    <Configuration>Debug</Configuration>
+                    <Platform>Win32</Platform>
+                </ProjectConfiguration>
+                <ProjectConfiguration Include="Release|Win32">
+                    <Configuration>Release</Configuration>
+                    <Platform>Win32</Platform>
+                </ProjectConfiguration>
+            </ItemGroup>
+            <PropertyGroup>
+                <ConfigurationType>Application</ConfigurationType>
+            </PropertyGroup>
+            {(sources.Length > 0 ? $"""
+            <ItemGroup>
+                {string.Join(Environment.NewLine, sources.Select(s => $"                <ClCompile Include=\"{s}\" />"))}
+            </ItemGroup>
+            """ : string.Empty)}
+        </Project>
+        """;
+
+        [Fact]
+        public void Given_ProjectWithoutSources_When_Converted_Then_NoLanguagesWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject()));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("project(Project)", cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithOnlyCFiles_When_Converted_Then_LanguageIsC()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("main.c")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("project(Project LANGUAGES C)", cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithOnlyCppFiles_When_Converted_Then_LanguageIsCxx()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("main.cpp")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("project(Project LANGUAGES CXX)", cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithCandCppFiles_When_Converted_Then_LanguagesAreCandCxx()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("main.c", "main.cpp")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("project(Project LANGUAGES C CXX)", cmake);
+        }
+    }
+
     public class ResolveProjectReferencesTests
     {
         [Fact]


### PR DESCRIPTION
## Summary
- refactor LanguageDetectionTests project helper to use multiline strings
- assert entire project line when checking LANGUAGES detection

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851dc216708832fb80169acf11ab6e6