### PR TITLE
Add LinkerSubsystem unit tests

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -869,4 +869,104 @@ public class ConverterTests
                 logger.AllMessageText);
         }
     }
+
+    public class LinkerSubsystemTests
+    {
+        private static string CreateProjectWithSubsystem(string debugSubsystem, string releaseSubsystem) => $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup Label="ProjectConfigurations">
+                    <ProjectConfiguration Include="Debug|Win32">
+                        <Configuration>Debug</Configuration>
+                        <Platform>Win32</Platform>
+                    </ProjectConfiguration>
+                    <ProjectConfiguration Include="Release|Win32">
+                        <Configuration>Release</Configuration>
+                        <Platform>Win32</Platform>
+                    </ProjectConfiguration>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ConfigurationType>Application</ConfigurationType>
+                </PropertyGroup>
+                <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+                    <Link>
+                        <SubSystem>{debugSubsystem}</SubSystem>
+                    </Link>
+                </ItemDefinitionGroup>
+                <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+                    <Link>
+                        <SubSystem>{releaseSubsystem}</SubSystem>
+                    </Link>
+                </ItemDefinitionGroup>
+            </Project>
+            """;
+        [Fact]
+        public void Given_ProjectWithWindowsSubsystem_When_Converted_Then_AddExecutableContainsWin32()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProjectWithSubsystem("Windows", "Windows")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("add_executable(Project WIN32", cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithConsoleSubsystem_When_Converted_Then_AddExecutableDoesNotContainWin32()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProjectWithSubsystem("Console", "Console")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.DoesNotContain("WIN32", cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithInconsistentSubsystem_When_Converted_Then_Throws()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProjectWithSubsystem("Windows", "Console")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            var ex = Assert.Throws<CatastrophicFailureException>(() =>
+                converter.Convert(
+                    projectFiles: [new(@"Project.vcxproj")],
+                    solutionFile: null,
+                    qtVersion: null,
+                    enableStandaloneProjectBuilds: false,
+                    indentStyle: "spaces",
+                    indentSize: 4,
+                    dryRun: false));
+
+            Assert.Contains("SubSystem property is inconsistent between configurations", ex.Message);
+        }
+    }
 }

--- a/vcxproj2cmake.Tests/TestData.cs
+++ b/vcxproj2cmake.Tests/TestData.cs
@@ -103,4 +103,5 @@ internal class TestData
             """ : string.Empty)}
         </Project>
         """;
+
 }


### PR DESCRIPTION
## Summary
- add a helper method to craft projects with a custom Linker Subsystem
- test WIN32 generation for Windows subsystem
- test absence of WIN32 for Console subsystem
- verify inconsistent subsystem values throw errors
- move helper from TestData into LinkerSubsystemTests

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6851e7af8318832f9ea2910eb48a7ecd