### PR TITLE
Add tests for target_link_libraries output

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -1148,6 +1148,120 @@ public class ConverterTests
         }
     }
 
+    public class AdditionalDependenciesTests
+    {
+        [Fact]
+        public void Given_ProjectWithAdditionalDependencies_When_Converted_Then_LibrariesAreLinked()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                    <ItemGroup Label="ProjectConfigurations">
+                        <ProjectConfiguration Include="Debug|Win32">
+                            <Configuration>Debug</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                        <ProjectConfiguration Include="Release|Win32">
+                            <Configuration>Release</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                    </ItemGroup>
+                    <PropertyGroup>
+                        <ConfigurationType>Application</ConfigurationType>
+                    </PropertyGroup>
+                    <ItemDefinitionGroup>
+                        <Link>
+                            <AdditionalDependencies>Foo.lib;Bar.lib;%(AdditionalDependencies)</AdditionalDependencies>
+                        </Link>
+                    </ItemDefinitionGroup>
+                </Project>
+                """));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains(
+                """
+                target_link_libraries(Project
+                    PUBLIC
+                        Foo.lib
+                        Bar.lib
+                )
+                """.Trim(),
+                cmake);
+        }
+
+        [Fact]
+        public void Given_ProjectWithConfigSpecificAdditionalDependencies_When_Converted_Then_GeneratorExpressionsUsed()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                    <ItemGroup Label="ProjectConfigurations">
+                        <ProjectConfiguration Include="Debug|Win32">
+                            <Configuration>Debug</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                        <ProjectConfiguration Include="Release|Win32">
+                            <Configuration>Release</Configuration>
+                            <Platform>Win32</Platform>
+                        </ProjectConfiguration>
+                    </ItemGroup>
+                    <PropertyGroup>
+                        <ConfigurationType>Application</ConfigurationType>
+                    </PropertyGroup>
+                    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+                        <Link>
+                            <AdditionalDependencies>Foo_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+                        </Link>
+                    </ItemDefinitionGroup>
+                    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+                        <Link>
+                            <AdditionalDependencies>Foo.lib;%(AdditionalDependencies)</AdditionalDependencies>
+                        </Link>
+                    </ItemDefinitionGroup>
+                </Project>
+                """));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains(
+                """
+                target_link_libraries(Project
+                    PUBLIC
+                        $<$<CONFIG:Debug>:Foo_d.lib>
+                        $<$<CONFIG:Release>:Foo.lib>
+                )
+                """.Trim(),
+                cmake);
+        }
+    }
+
     public class OpenMPSupportTests
     {
         static string CreateProject(string debugValue, string releaseValue) => $"""


### PR DESCRIPTION
## Summary
- test that AdditionalDependencies are converted to `target_link_libraries`
- test configuration-specific library handling

## Testing
- `dotnet test vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68531b4194c4832f97ce313541dc1f60