### PR TITLE
Add compiler options tests

### DIFF
--- a/vcxproj2cmake.Tests/ConverterTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests.cs
@@ -1502,4 +1502,269 @@ public class ConverterTests
             Assert.Contains("SubSystem property is inconsistent between configurations", ex.Message);
         }
     }
+
+    public class CompilerOptionsTests
+    {
+        static string CreateProject(string property, string debugValue, string releaseValue) => $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup Label="ProjectConfigurations">
+                    <ProjectConfiguration Include="Debug|Win32">
+                        <Configuration>Debug</Configuration>
+                        <Platform>Win32</Platform>
+                    </ProjectConfiguration>
+                    <ProjectConfiguration Include="Release|Win32">
+                        <Configuration>Release</Configuration>
+                        <Platform>Win32</Platform>
+                    </ProjectConfiguration>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ConfigurationType>Application</ConfigurationType>
+                </PropertyGroup>
+                <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+                    <ClCompile>
+                        <{property}>{debugValue}</{property}>
+                    </ClCompile>
+                </ItemDefinitionGroup>
+                <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+                    <ClCompile>
+                        <{property}>{releaseValue}</{property}>
+                    </ClCompile>
+                </ItemDefinitionGroup>
+            </Project>
+            """;
+
+
+        [Fact]
+        public void Given_AdditionalOptions_When_Converted_Then_OptionsAreWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("AdditionalOptions", "foo bar", "foo bar")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        foo
+                        bar
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_DisableSpecificWarnings_When_Converted_Then_WdOptionsAreWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("DisableSpecificWarnings", "4100;4200", "4100;4200")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /wd4100
+                        /wd4200
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_TreatSpecificWarningsAsErrors_When_Converted_Then_WeOptionsAreWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("TreatSpecificWarningsAsErrors", "4800;4801", "4800;4801")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /we4800
+                        /we4801
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_TreatWarningAsError_When_Converted_Then_WxOptionIsWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("TreatWarningAsError", "true", "true")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /WX
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_WarningLevel_When_Converted_Then_WOptionIsWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("WarningLevel", "Level4", "Level4")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /W4
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_InvalidWarningLevel_When_Converted_Then_Throws()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("WarningLevel", "Bad", "Bad")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            Assert.Throws<CatastrophicFailureException>(() => converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false));
+        }
+
+        [Fact]
+        public void Given_ExternalWarningLevel_When_Converted_Then_ExternalWOptionIsWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("ExternalWarningLevel", "Level2", "Level2")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /external:W2
+                )
+                """.TrimEnd(), cmake);
+        }
+
+        [Fact]
+        public void Given_InvalidExternalWarningLevel_When_Converted_Then_Throws()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("ExternalWarningLevel", "Foo", "Foo")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+
+            Assert.Throws<CatastrophicFailureException>(() => converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false));
+        }
+
+        [Fact]
+        public void Given_TreatAngleIncludeAsExternal_When_Converted_Then_AngleBracketsOptionIsWritten()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(CreateProject("TreatAngleIncludeAsExternal", "true", "true")));
+
+            var converter = new Converter(fileSystem, NullLogger.Instance);
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")],
+                solutionFile: null,
+                qtVersion: null,
+                enableStandaloneProjectBuilds: false,
+                indentStyle: "spaces",
+                indentSize: 4,
+                dryRun: false);
+
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+            Assert.Contains("""
+                target_compile_options(Project
+                    PUBLIC
+                        /external:anglebrackets
+                )
+                """.TrimEnd(), cmake);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `CompilerOptionsTests` to check converter output for target_compile_options
- cover additional options, warning level settings, external warnings, and more
- ensure tests verify complete `target_compile_options` commands
- inline converter calls in each test for clarity

## Testing
- `dotnet test vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68531b4bc4ac832fab627ce598506813