### PR TITLE
Fix compiler warning by adding RuntimeIdentifier to tests project

### DIFF
--- a/vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj
+++ b/vcxproj2cmake.Tests/vcxproj2cmake.Tests.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <RuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This should fix #34.