### PR TITLE
Add openglwidgets module

### DIFF
--- a/vcxproj2cmake/QtModuleInfoRepository.cs
+++ b/vcxproj2cmake/QtModuleInfoRepository.cs
@@ -55,6 +55,7 @@ class QtModuleInfoRepository
         { "nfc",                "Nfc" },
         { "opcua",              "OpcUa" },
         { "opengl",             "OpenGL" },
+        { "openglwidgets",      "OpenGLWidgets" },
         { "pdf",                "Pdf" },
         { "platformheaders",    "PlatformHeaders" },
         { "positioning",        "Positioning" },


### PR DESCRIPTION
Thanks for this excellent tool, it alleviates the chore of porting from vcxproj to cmake quite a bit!
When converting some Qt6-based projects, it reported though: `Error: Unknown Qt module: openglwidgets`.

Qt 6 has a [QtOpenGLModule](https://doc.qt.io/qt-6/qopenglwidget.html). This PR adds the capability of handling that module.