### PR TITLE
Avoid warnings for default include/library paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Avoid warnings by ignoring certain default values in `IncludePath` and `LibraryPath` MSBuild properties.
+
 ## [1.9.0] - 2026-05-31
 
 ### Added

--- a/vcxproj2cmake.Tests/ConverterTests/IncludePathTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests/IncludePathTests.cs
@@ -100,6 +100,40 @@ public partial class ConverterTests
         }
 
         [Fact]
+        public void Given_ProjectWithDefaultIncludePaths_When_Converted_Then_ValuesAreIgnoredAndNoWarningsAreGenerated()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(TestData.Project()
+                .WithProperty("Debug", "Win32", "IncludePath", "debuginc;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(IncludePath)")
+                .WithProperty("Release", "Win32", "IncludePath", "releaseinc;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(IncludePath)")
+                .Build()));
+
+            var logger = new InMemoryLogger();
+            var converter = new Converter(fileSystem, logger);
+
+            // Act
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")]);
+
+            // Assert
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+
+            Assert.Contains("""
+                target_include_directories(Project
+                    PRIVATE
+                        "$<$<CONFIG:Debug>:${CMAKE_CURRENT_SOURCE_DIR}/debuginc>"
+                        "$<$<CONFIG:Release>:${CMAKE_CURRENT_SOURCE_DIR}/releaseinc>"
+                )
+                """, cmake);
+
+            Assert.DoesNotContain("VC_IncludePath", logger.AllMessageText);
+            Assert.DoesNotContain("WindowsSDK_IncludePath", logger.AllMessageText);
+        }
+
+        [Fact]
         public void Given_ProjectWithPublicIncludeDirectories_When_Converted_Then_InterfacePathsAreWritten()
         {
             // Arrange

--- a/vcxproj2cmake.Tests/ConverterTests/LinkerLibraryDirectoriesTests.cs
+++ b/vcxproj2cmake.Tests/ConverterTests/LinkerLibraryDirectoriesTests.cs
@@ -126,5 +126,49 @@ public partial class ConverterTests
                 )
                 """, cmake);
         }
+
+        [Fact]
+        public void Given_ProjectWithDefaultLibraryPaths_When_Converted_Then_ValuesAreIgnoredAndNoWarningsAreGenerated()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(Environment.CurrentDirectory);
+
+            fileSystem.AddFile(@"Project.vcxproj", new(TestData.Project()
+                .WithProperty("Debug", "Win32", "LibraryPath", "debuglib;$(VC_LibraryPath_x86);$(VC_LibraryPath_x64);$(VC_LibraryPath_ARM);$(VC_LibraryPath_ARM64);$(WindowsSDK_LibraryPath_x86);$(WindowsSDK_LibraryPath_x64);$(WindowsSDK_LibraryPath_ARM);$(WindowsSDK_LibraryPath_ARM64);$(NETFXKitsDir)Lib\\um\\x86;$(NETFXKitsDir)Lib\\um\\x64;$(NETFXKitsDir)Lib\\um\\arm;$(NETFXKitsDir)Lib\\um\\arm64;$(LibraryPath)")
+                .WithProperty("Release", "Win32", "LibraryPath", "releaselib;$(VC_LibraryPath_x86);$(VC_LibraryPath_x64);$(VC_LibraryPath_ARM);$(VC_LibraryPath_ARM64);$(WindowsSDK_LibraryPath_x86);$(WindowsSDK_LibraryPath_x64);$(WindowsSDK_LibraryPath_ARM);$(WindowsSDK_LibraryPath_ARM64);$(NETFXKitsDir)Lib\\um\\x86;$(NETFXKitsDir)Lib\\um\\x64;$(NETFXKitsDir)Lib\\um\\arm;$(NETFXKitsDir)Lib\\um\\arm64;$(LibraryPath)")
+                .Build()));
+
+            var logger = new InMemoryLogger();
+            var converter = new Converter(fileSystem, logger);
+
+            // Act
+            converter.Convert(
+                projectFiles: [new(@"Project.vcxproj")]);
+
+            // Assert
+            var cmake = fileSystem.GetFile(@"CMakeLists.txt").TextContents;
+
+            Assert.Contains("""
+                target_link_directories(Project
+                    PRIVATE
+                        "$<$<CONFIG:Debug>:debuglib>"
+                        "$<$<CONFIG:Release>:releaselib>"
+                )
+                """, cmake);
+
+            Assert.DoesNotContain(@"VC_LibraryPath_x86", logger.AllMessageText);
+            Assert.DoesNotContain(@"VC_LibraryPath_x64", logger.AllMessageText);
+            Assert.DoesNotContain(@"VC_LibraryPath_ARM", logger.AllMessageText);
+            Assert.DoesNotContain(@"VC_LibraryPath_ARM64", logger.AllMessageText);
+            Assert.DoesNotContain(@"WindowsSDK_LibraryPath_x86", logger.AllMessageText);
+            Assert.DoesNotContain(@"WindowsSDK_LibraryPath_x64", logger.AllMessageText);
+            Assert.DoesNotContain(@"WindowsSDK_LibraryPath_ARM", logger.AllMessageText);
+            Assert.DoesNotContain(@"WindowsSDK_LibraryPath_ARM64", logger.AllMessageText);
+            Assert.DoesNotContain(@"$(NETFXKitsDir)Lib\\um\\x86", logger.AllMessageText);
+            Assert.DoesNotContain(@"$(NETFXKitsDir)Lib\\um\\x64", logger.AllMessageText);
+            Assert.DoesNotContain(@"$(NETFXKitsDir)Lib\\um\\arm", logger.AllMessageText);
+            Assert.DoesNotContain(@"$(NETFXKitsDir)Lib\\um\\arm64", logger.AllMessageText);
+        }
     }
 }

--- a/vcxproj2cmake/CMakeProject.cs
+++ b/vcxproj2cmake/CMakeProject.cs
@@ -29,6 +29,24 @@ class CMakeProject
     public bool IsWin32Executable { get; set; }
     public CMakeConfigDependentSetting PrecompiledHeaderFile { get; set; }
 
+    static readonly CMakeExpression[] IgnoredIncludePaths = [
+        CMakeExpression.Expression(@"\$(VC_IncludePath)"),
+        CMakeExpression.Expression(@"\$(WindowsSDK_IncludePath)")];
+
+    static readonly CMakeExpression[] IgnoredLibraryPaths = [
+        CMakeExpression.Expression(@"\$(VC_LibraryPath_x86)"),
+        CMakeExpression.Expression(@"\$(VC_LibraryPath_x64)"),
+        CMakeExpression.Expression(@"\$(VC_LibraryPath_ARM)"),
+        CMakeExpression.Expression(@"\$(VC_LibraryPath_ARM64)"),
+        CMakeExpression.Expression(@"\$(WindowsSDK_LibraryPath_x86)"),
+        CMakeExpression.Expression(@"\$(WindowsSDK_LibraryPath_x64)"),
+        CMakeExpression.Expression(@"\$(WindowsSDK_LibraryPath_ARM)"),
+        CMakeExpression.Expression(@"\$(WindowsSDK_LibraryPath_ARM64)"),
+        CMakeExpression.Expression(@"\$(NETFXKitsDir)Lib\\um\\x86"),
+        CMakeExpression.Expression(@"\$(NETFXKitsDir)Lib\\um\\x64"),
+        CMakeExpression.Expression(@"\$(NETFXKitsDir)Lib\\um\\arm"),
+        CMakeExpression.Expression(@"\$(NETFXKitsDir)Lib\\um\\arm64")];
+
     public CMakeProject(MSBuildProject project, CMakeProjectSettings settings, bool includeHeaders, ConanPackageInfoRepository conanPackageInfoRepository, ILogger logger)
     {
         logger.LogInformation($"Processing project {project.AbsoluteProjectPath}");
@@ -58,7 +76,10 @@ class CMakeProject
         var mergedIncludeDirectories = MergeIncludeDirectories(project, supportedProjectConfigurations);
         IncludePaths = CMakeConfigDependentMultiSetting.FromMSBuildSetting(
             mergedIncludeDirectories,
-            values => values.Select(value => TranslateAndNormalize(value, "AdditionalIncludeDirectories+IncludePath", logger)).ToArray(),
+            values => values
+                .Except(IgnoredIncludePaths)
+                .Select(value => TranslateAndNormalize(value, "AdditionalIncludeDirectories+IncludePath", logger))
+                .ToArray(),
             supportedProjectConfigurations,
             logger);
         PublicIncludePaths = CMakeConfigDependentMultiSetting.FromMSBuildSetting(
@@ -69,7 +90,10 @@ class CMakeProject
         var mergedLibraryDirectories = MergeLibraryDirectories(project, supportedProjectConfigurations);
         LinkerPaths = CMakeConfigDependentMultiSetting.FromMSBuildSetting(
             mergedLibraryDirectories,
-            values => values.Select(value => TranslateAndNormalize(value, "AdditionalLibraryDirectories+LibraryPath", logger)).ToArray(),
+            values => values
+                .Except(IgnoredLibraryPaths)
+                .Select(value => TranslateAndNormalize(value, "AdditionalLibraryDirectories+LibraryPath", logger))
+                .ToArray(),
             supportedProjectConfigurations,
             logger);
         Libraries = CMakeConfigDependentMultiSetting.FromMSBuildSetting(


### PR DESCRIPTION
This avoids some of the warnings reported by @SergeVDev at https://github.com/chausner/vcxproj2cmake/issues/58#issuecomment-4763349953 by adding logic to ignore a set of default values normally part of properties `IncludePath` and `LibraryPath`.